### PR TITLE
Remove unused rpclib.unix dependency from lib/jbuild

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -7,6 +7,5 @@
   (libraries (
     unix
     rpclib
-    rpclib.unix
   ))
 ))


### PR DESCRIPTION
Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>