### PR TITLE
maintenance: use rpclib

### DIFF
--- a/xapi-plugin.opam
+++ b/xapi-plugin.opam
@@ -11,6 +11,6 @@ depends: [
   "ocaml"
   "dune" {build}
   "base-unix"
-  "rpc"
+  "rpclib"
 ]
 synopsis: "Library to simplify writing xapi plugins in OCaml"


### PR DESCRIPTION
ppx_deriving_rpc is not needed, only xmlrpc and rpc functions are used for pretty-printing